### PR TITLE
Fix "Bananas, Lenses, Envelopes and Barbed Wire" link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # excellent-reading
 Some excellent reading, a collection of blog posts and papers I've found interesting:
 
-- [Functional Programming with Bananas, Lenses, Envelopes and Barbed Wire](http://www.codecommit.com/blog/scala/what-is-hindley-milner-and-why-is-it-cool) - Erik Meijer, Maarten Fokkinga, Ross Paterson
+- [Functional Programming with Bananas, Lenses, Envelopes and Barbed Wire](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.41.125&rep=rep1&type=pdf) - Erik Meijer, Maarten Fokkinga, Ross Paterson
 - [What is Hindley-Milner, and why is it Cool?](http://www.codecommit.com/blog/scala/what-is-hindley-milner-and-why-is-it-cool) - Daniel Spiewak
 - [A position paper on Software Reliability](http://www.cs.utexas.edu/~EWD/ewd06xx/EWD627.PDF) - Edsger W. Dijkstra


### PR DESCRIPTION
Thanks for the reading material!